### PR TITLE
Add missing emit for explore buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/map-utilities",
-  "version": "0.0.0-beta.4",
+  "version": "0.0.0-beta.5",
   "files": [
     "dist/*",
     "src/*",

--- a/src/App.vue
+++ b/src/App.vue
@@ -117,6 +117,10 @@ function onFinishHelpMode() {
   helpModeActiveItem.value = 0;
   helpModeLastItem.value = false;
 }
+function onActionClick(value) {
+  console.log("🚀 ~ onActionClick ~ value:", value);
+}
+
 /**
  * Tooltip
  */
@@ -461,6 +465,7 @@ function changeHover(value) {
       :annotationDisplay="annotationDisplay"
       :annotationEntry="annotationEntry"
       @annotation="commitAnnotationEvent"
+      @onActionClick="onActionClick"
     />
     <TreeControls
       v-show="mapType === 'flatmap'"

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -13,6 +13,8 @@
 </template>
 
 <script>
+import EventBus from '../EventBus.js';
+
 export default {
   name: "Tooltip",
   props: {
@@ -26,6 +28,12 @@ export default {
     annotationEntry: {
       type: Object,
     },
+  },
+  mounted: function() {
+    // Emit events from child components
+    EventBus.on("onActionClick", (data) => {
+      this.$emit("onActionClick", data);
+    });
   },
 };
 </script>


### PR DESCRIPTION
This fixes the issue where the buttons were opening the sidebar with no results. 

From Domonic

 

> When clicking on "Explore Origin Data" you are taken to the Search tab and I was given 0 results but there was no search keywords or filters present. Would expect something to be present as search parameters (I used Neuron type bromo 1 for my search)
> Same as above for "Explore Destination Data" and "Search for data on components"