### PR TITLE
Connectivity Graph Layout Fix - Breadthfirst

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,13 +39,16 @@ const drawnTypes = [
   { value: "None", label: "None" },
 ];
 const showConnectivityGraph = ref(false);
-const connectivityGraphEntry = "ilxtr:neuron-type-aacar-13";
-// const connectivityGraphEntry = "ilxtr:sparc-nlp/kidney/134";
-// const connectivityGraphEntry = "ilxtr:neuron-type-aacar-11";
-// const connectivityGraphEntry = "ilxtr:neuron-type-sstom-14";
-// const connectivityGraphEntry = "ilxtr:neuron-type-keast-6";
-// const connectivityGraphEntry = "ilxtr:neuron-type-aacar-4";
-// const connectivityGraphEntry = "ilxtr:neuron-type-aacar-12";
+const connectivityGraphEntry = ref("ilxtr:neuron-type-aacar-13");
+const connectivityGraphEntries = [
+  "ilxtr:neuron-type-aacar-13",
+  "ilxtr:sparc-nlp/kidney/134",
+  "ilxtr:neuron-type-aacar-11",
+  "ilxtr:neuron-type-sstom-14",
+  "ilxtr:neuron-type-keast-6",
+  "ilxtr:neuron-type-aacar-4",
+  "ilxtr:neuron-type-aacar-12",
+];
 const mapServer = "https://mapcore-demo.org/curation/flatmap/";
 const sckanVersion = "sckan-2024-09-21-npo";
 
@@ -479,10 +482,24 @@ function confirmCreate(value) {
         >
           Hide connectivity graph
         </el-button>
+        <el-select
+          v-model="connectivityGraphEntry"
+          placeholder="Select featureId"
+          style="width: 180px"
+          size="small"
+        >
+          <el-option
+            v-for="item in connectivityGraphEntries"
+            :key="item"
+            :label="item"
+            :value="item"
+          />
+        </el-select>
       </el-col>
       <el-col>
         <ConnectivityGraph
           v-if="showConnectivityGraph"
+          :key="connectivityGraphEntry"
           :entry="connectivityGraphEntry"
           :map-server="mapServer"
           :sckanVersion="sckanVersion"
@@ -590,5 +607,8 @@ function confirmCreate(value) {
   width: 600px;
   height: 600px;
   margin-top: 1rem;
+}
+.el-button + .el-select {
+  margin-left: 12px;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -480,6 +480,14 @@ function confirmCreate(value) {
           Hide connectivity graph
         </el-button>
       </el-col>
+      <el-col>
+        <ConnectivityGraph
+          v-if="showConnectivityGraph"
+          :entry="connectivityGraphEntry"
+          :map-server="mapServer"
+          :sckanVersion="sckanVersion"
+        />
+      </el-col>
     </el-row>
 
     <DrawToolbar
@@ -549,12 +557,6 @@ function confirmCreate(value) {
       :showColourPicker="true"
       @setColour="setColour"
       @checkChanged="checkChanged"
-    />
-    <ConnectivityGraph
-      v-if="showConnectivityGraph"
-      :entry="connectivityGraphEntry"
-      :map-server="mapServer"
-      :sckanVersion="sckanVersion"
     />
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -41,6 +41,10 @@ const drawnTypes = [
 const showConnectivityGraph = ref(false);
 const connectivityGraphEntry = "ilxtr:neuron-type-aacar-13";
 // const connectivityGraphEntry = "ilxtr:sparc-nlp/kidney/134";
+// const connectivityGraphEntry = "ilxtr:neuron-type-aacar-11";
+// const connectivityGraphEntry = "ilxtr:neuron-type-sstom-14";
+// const connectivityGraphEntry = "ilxtr:neuron-type-keast-6";
+// const connectivityGraphEntry = "ilxtr:neuron-type-aacar-4"
 const mapServer = "https://mapcore-demo.org/curation/flatmap/";
 const sckanVersion = "sckan-2024-09-21-npo";
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -44,7 +44,8 @@ const connectivityGraphEntry = "ilxtr:neuron-type-aacar-13";
 // const connectivityGraphEntry = "ilxtr:neuron-type-aacar-11";
 // const connectivityGraphEntry = "ilxtr:neuron-type-sstom-14";
 // const connectivityGraphEntry = "ilxtr:neuron-type-keast-6";
-// const connectivityGraphEntry = "ilxtr:neuron-type-aacar-4"
+// const connectivityGraphEntry = "ilxtr:neuron-type-aacar-4";
+// const connectivityGraphEntry = "ilxtr:neuron-type-aacar-12";
 const mapServer = "https://mapcore-demo.org/curation/flatmap/";
 const sckanVersion = "sckan-2024-09-21-npo";
 

--- a/src/components/ConnectivityGraph/graph.js
+++ b/src/components/ConnectivityGraph/graph.js
@@ -330,10 +330,13 @@ class CytoscapeGraph extends EventTarget
             elements: connectivityGraph.elements,
             layout: {
                 name: 'breadthfirst',
-                circle: false,
-                roots: connectivityGraph.roots
+                directed: true,
+                depthSort: function (a, b) {
+                    // TODO: to sort based on connections
+                    return a.data('id') - b.data('id');
+                },
+                roots: connectivityGraph.roots.length ? connectivityGraph.roots : undefined,
             },
-            directed: true,
             style: GRAPH_STYLE,
             minZoom: 0.1,
             maxZoom: 10,


### PR DESCRIPTION
The option to reduce the overlapping nodes issue with `breadthfirst` layout.
This will fix for some connections but not for all. 