### PR TITLE
Minor style fix

### DIFF
--- a/src/components/DrawToolbar/DrawToolbar.vue
+++ b/src/components/DrawToolbar/DrawToolbar.vue
@@ -573,7 +573,7 @@ export default {
   border-color: var(--el-color-primary-light-5);
   border-radius: 1rem;
   position: absolute;
-  right: 30%;
+  right: 40%;
   bottom: 1rem;
   z-index: 10;
 }

--- a/src/components/DrawToolbar/DrawToolbar.vue
+++ b/src/components/DrawToolbar/DrawToolbar.vue
@@ -573,8 +573,8 @@ export default {
   border-color: var(--el-color-primary-light-5);
   border-radius: 1rem;
   position: absolute;
-  right: calc(50vw - 100px);
-  bottom: 16px;
+  right: 30%;
+  bottom: 1rem;
   z-index: 10;
 }
 


### PR DESCRIPTION
Make sure toobar at right position when split screen applied in mapviewer

before:
<img width="1485" alt="Screenshot 2025-05-09 at 11 50 01 AM" src="https://github.com/user-attachments/assets/02e39c36-c12a-4e9d-bce0-71321d6a538c" />

after:
<img width="1487" alt="Screenshot 2025-05-09 at 11 58 02 AM" src="https://github.com/user-attachments/assets/047a2582-7d16-485a-ba4f-8724a3bdfe8f" />


6 hor:
<img width="1494" alt="Screenshot 2025-05-09 at 11 56 15 AM" src="https://github.com/user-attachments/assets/3c5a319a-6113-45a2-8fdf-14bdd20dce8d" />
