### PR TITLE
Magnify glass search

### DIFF
--- a/src/components/ConnectivityGraph/ConnectivityGraph.vue
+++ b/src/components/ConnectivityGraph/ConnectivityGraph.vue
@@ -110,10 +110,8 @@
       </div>
     </div>
 
-    <div v-if="connectivityError" class="connectivity-graph-error">
-      <strong v-if="connectivityError.errorConnectivities">
-        {{ connectivityError.errorConnectivities }}
-      </strong>
+    <div v-show="connectivityError.errorConnectivities" class="connectivity-graph-error">
+      <strong>{{ connectivityError.errorConnectivities }}</strong>
       {{ connectivityError.errorMessage }}
     </div>
 
@@ -136,7 +134,6 @@ const ZOOM_IN_LABEL = 'Zoom in';
 const ZOOM_OUT_LABEL = 'Zoom out';
 const ZOOM_INCREMENT = 0.25;
 const APP_PRIMARY_COLOR = '#8300bf';
-const ERROR_TIMEOUT = 3000; // 3 seconds
 
 export default {
   name: 'ConnectivityGraph',
@@ -164,6 +161,10 @@ export default {
       type: Object,
       default: () => null,
     },
+    connectivityError: {
+      type: Object,
+      default: () => {},
+    }
   },
   data: function () {
     return {
@@ -183,8 +184,6 @@ export default {
       zoomOutLabel: ZOOM_OUT_LABEL,
       iconColor: APP_PRIMARY_COLOR,
       zoomEnabled: false,
-      connectivityError: null,
-      timeoutID: undefined,
       connectivityGraphContainer: null,
     };
   },
@@ -505,18 +504,7 @@ export default {
       this.zoomEnabled = !this.zoomEnabled;
       this.zoomLockLabel = this.zoomEnabled ? ZOOM_UNLOCK_LABEL : ZOOM_LOCK_LABEL;
       this.connectivityGraph.enableZoom(!this.zoomEnabled);
-    },
-    showErrorMessage: function (connectivityError) {
-      this.connectivityError = {...connectivityError};
-
-      if (this.timeoutID) {
-        clearTimeout(this.timeoutID);
-      }
-
-      this.timeoutID = setTimeout(() => {
-        this.connectivityError = null;
-      }, ERROR_TIMEOUT);
-    },
+    }
   },
 };
 </script>

--- a/src/components/ConnectivityList/ConnectivityList.vue
+++ b/src/components/ConnectivityList/ConnectivityList.vue
@@ -29,6 +29,7 @@
         <span>{{ capitalise(origin) }}</span>
         <el-icon 
           class="connectivity-search-icon" 
+          v-show="validateConnectivity(origin)"
           @click="onConnectivityClicked(origin)"
         >
           <el-icon-search />
@@ -64,6 +65,7 @@
       <span>{{ capitalise(component) }}</span>
         <el-icon 
           class="connectivity-search-icon" 
+          v-show="validateConnectivity(component)"
           @click="onConnectivityClicked(component)"
         >
           <el-icon-search />
@@ -101,6 +103,7 @@
         <span>{{ capitalise(destination) }}</span>
         <el-icon 
           class="connectivity-search-icon" 
+          v-show="validateConnectivity(destination)"
           @click="onConnectivityClicked(destination)"
         >
           <el-icon-search />
@@ -135,10 +138,8 @@
     </div>
 
     <div class="connectivity-error-container">
-      <div class="connectivity-error" v-if="connectivityError">
-        <strong v-if="connectivityError.errorConnectivities">
-          {{ connectivityError.errorConnectivities }}
-        </strong>
+      <div class="connectivity-error" v-show="connectivityError.errorConnectivities">
+        <strong>{{ connectivityError.errorConnectivities }}</strong>
         {{ connectivityError.errorMessage }}
       </div>
     </div>
@@ -210,7 +211,7 @@ export default {
     },
     connectivityError: {
       type: Object,
-      default: () => null,
+      default: () => {},
     }
   },
   data: function () {
@@ -220,7 +221,6 @@ export default {
         sensory: 'is the location of the initial cell body in the PNS circuit',
       },
       facetList: [],
-      sckanVersion: '',
     }
   },
   watch: {
@@ -253,7 +253,15 @@ export default {
       this.$emit('connectivity-hovered', name);
     },
     onConnectivityClicked: function (name) {
-      this.$emit('connectivity-clicked', name);
+      const connectivity = this.connectivityError?.errorConnectivities;
+      const label = connectivity
+        ? name.replace(new RegExp(`\\s*,?\\s*${connectivity}\\s*,?\\s*`, 'gi'), '').trim()
+        : name;
+      this.$emit('connectivity-clicked', label);
+    },
+    validateConnectivity: function (features) {
+      const connectivity = this.connectivityError?.errorConnectivities;
+      return connectivity?.toLowerCase() !== features.toLowerCase();
     },
     // shouldShowExploreButton: Checks if the feature is in the list of available anatomy facets
     shouldShowExploreButton: function (features) {

--- a/src/components/ConnectivityList/ConnectivityList.vue
+++ b/src/components/ConnectivityList/ConnectivityList.vue
@@ -27,8 +27,8 @@
         @mouseleave="onConnectivityHovered()"
       >
         <el-icon 
-          class="connectivity-search-icon" 
-          v-show="validateConnectivity(origin)"
+          class="magnify-glass"
+          v-show="shouldShowMagnifyGlass(origin)"
           @click="onConnectivityClicked(origin)"
         >
           <el-icon-search />
@@ -63,8 +63,8 @@
         @mouseleave="onConnectivityHovered()"
       >
         <el-icon 
-          class="connectivity-search-icon" 
-          v-show="validateConnectivity(component)"
+          class="magnify-glass"
+          v-show="shouldShowMagnifyGlass(component)"
           @click="onConnectivityClicked(component)"
         >
           <el-icon-search />
@@ -101,8 +101,8 @@
         @mouseleave="onConnectivityHovered()"
       >
         <el-icon 
-          class="connectivity-search-icon" 
-          v-show="validateConnectivity(destination)"
+          class="magnify-glass"
+          v-show="shouldShowMagnifyGlass(destination)"
           @click="onConnectivityClicked(destination)"
         >
           <el-icon-search />
@@ -253,16 +253,16 @@ export default {
       this.$emit('connectivity-hovered', name);
     },
     onConnectivityClicked: function (name) {
-      const connectivity = this.connectivityError?.errorConnectivities;
+      const connectivity = this.connectivityError.errorConnectivities;
       // Remove the invalid term while searching
       const label = connectivity
         ? name.replace(new RegExp(`\\s*,?\\s*${connectivity}\\s*,?\\s*`, 'gi'), '').trim()
         : name;
       this.$emit('connectivity-clicked', label);
     },
-    // validateConnectivity: Checks whether the hovered terms contain valid term or not
-    validateConnectivity: function (features) {
-      const connectivity = this.connectivityError?.errorConnectivities;
+    // shouldShowMagnifyGlass: Checks whether the hovered terms contain valid term or not
+    shouldShowMagnifyGlass: function (features) {
+      const connectivity = this.connectivityError.errorConnectivities;
       return connectivity?.toLowerCase() !== features.toLowerCase();
     },
     // shouldShowExploreButton: Checks if the feature is in the list of available anatomy facets
@@ -378,25 +378,27 @@ export default {
 }
 
 .attribute-content {
-  display: flex;
   font-size: 14px;
   font-weight: 500;
   transition: color 0.25s ease;
   position: relative;
   cursor: default;
+  padding-left: 16px;
 
-  .connectivity-search-icon {
+  .magnify-glass {
     display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
   }
 
   &:hover {
     color: $app-primary-color;
 
-    .connectivity-search-icon {
-      margin-right: 4px;
+    .magnify-glass {
+      display: block;
       padding-top: 4px;
       cursor: pointer;
-      display: block;
     }
   }
 

--- a/src/components/ConnectivityList/ConnectivityList.vue
+++ b/src/components/ConnectivityList/ConnectivityList.vue
@@ -26,7 +26,6 @@
         @mouseenter="onConnectivityHovered(origin)"
         @mouseleave="onConnectivityHovered()"
       >
-        <span>{{ capitalise(origin) }}</span>
         <el-icon 
           class="connectivity-search-icon" 
           v-show="validateConnectivity(origin)"
@@ -34,6 +33,7 @@
         >
           <el-icon-search />
         </el-icon>
+        <span>{{ capitalise(origin) }}</span>
       </div>
       <el-button
         v-show="
@@ -62,7 +62,6 @@
         @mouseenter="onConnectivityHovered(component)"
         @mouseleave="onConnectivityHovered()"
       >
-      <span>{{ capitalise(component) }}</span>
         <el-icon 
           class="connectivity-search-icon" 
           v-show="validateConnectivity(component)"
@@ -70,6 +69,7 @@
         >
           <el-icon-search />
         </el-icon>
+        <span>{{ capitalise(component) }}</span>
       </div>
     </div>
     <div
@@ -100,7 +100,6 @@
         @mouseenter="onConnectivityHovered(destination)"
         @mouseleave="onConnectivityHovered()"
       >
-        <span>{{ capitalise(destination) }}</span>
         <el-icon 
           class="connectivity-search-icon" 
           v-show="validateConnectivity(destination)"
@@ -108,6 +107,7 @@
         >
           <el-icon-search />
         </el-icon>
+        <span>{{ capitalise(destination) }}</span>
       </div>
       <el-button
         v-show="
@@ -379,7 +379,6 @@ export default {
 
 .attribute-content {
   display: flex;
-  justify-content: space-between;
   font-size: 14px;
   font-weight: 500;
   transition: color 0.25s ease;
@@ -394,6 +393,7 @@ export default {
     color: $app-primary-color;
 
     .connectivity-search-icon {
+      margin-right: 4px;
       padding-top: 4px;
       cursor: pointer;
       display: block;

--- a/src/components/ConnectivityList/ConnectivityList.vue
+++ b/src/components/ConnectivityList/ConnectivityList.vue
@@ -254,11 +254,13 @@ export default {
     },
     onConnectivityClicked: function (name) {
       const connectivity = this.connectivityError?.errorConnectivities;
+      // Remove the invalid term while searching
       const label = connectivity
         ? name.replace(new RegExp(`\\s*,?\\s*${connectivity}\\s*,?\\s*`, 'gi'), '').trim()
         : name;
       this.$emit('connectivity-clicked', label);
     },
+    // validateConnectivity: Checks whether the hovered terms contain valid term or not
     validateConnectivity: function (features) {
       const connectivity = this.connectivityError?.errorConnectivities;
       return connectivity?.toLowerCase() !== features.toLowerCase();


### PR DESCRIPTION
- Hide magnify glass when there is no valid term for the hovered item.
- Show magnify glass but click to search part of the term when there are both valid and invalid terms for the hovered item.
- Make connectivity error on graph and list more consistent - pass connectivityError as props.