### PR TITLE
Prevent emit highlight change on annotation tab close

### DIFF
--- a/src/components/ConnectivityList/ConnectivityList.vue
+++ b/src/components/ConnectivityList/ConnectivityList.vue
@@ -52,7 +52,7 @@
             popper-class="popover-origin-help"
           >
             <template #reference>
-              <el-icon 
+              <el-icon
                 class="magnify-glass"
                 v-show="shouldShowMagnifyGlass(origin,)"
                 @click="onConnectivityClicked(origin)"
@@ -98,7 +98,7 @@
             popper-class="popover-origin-help"
           >
             <template #reference>
-              <el-icon 
+              <el-icon
                 class="magnify-glass"
                 v-show="shouldShowMagnifyGlass(component)"
                 @click="onConnectivityClicked(component)"
@@ -146,7 +146,7 @@
             popper-class="popover-origin-help"
           >
             <template #reference>
-              <el-icon 
+              <el-icon
                 class="magnify-glass"
                 v-show="shouldShowMagnifyGlass(destination)"
                 @click="onConnectivityClicked(destination)"
@@ -472,7 +472,7 @@ export default {
   right:0px;
 }
 
-:deep(.connectivity-error-container.el-popover) {
+.connectivity-list :deep(.connectivity-error-container.el-popover) {
   min-height: 31px; // placeholder
   align-items: center;
   justify-content: center;
@@ -481,5 +481,6 @@ export default {
   border-radius: var(--el-border-radius-small);
   border: 1px solid var(--el-color-error);
   pointer-events: none;
+  word-break: break-word;
 }
 </style>

--- a/src/components/Tooltip/AnnotationPopup.vue
+++ b/src/components/Tooltip/AnnotationPopup.vue
@@ -709,4 +709,8 @@ export default {
     }
   }
 }
+
+.annotation-popup :deep(.el-popover.el-popper) {
+  word-break: break-word;
+}
 </style>

--- a/src/components/Tooltip/AnnotationPopup.vue
+++ b/src/components/Tooltip/AnnotationPopup.vue
@@ -499,7 +499,10 @@ export default {
       handler: function (newVal, oldVal) {
         if (newVal !== oldVal) {
           this.entryIndex = 0;
-          this.emitActiveItemChange();
+
+          if (newVal?.length) {
+            this.emitActiveItemChange();
+          }
         }
       },
     },


### PR DESCRIPTION
### 1. Reset highlight after annotation tab is closed.

On annotation mode, clicking a neuron population on the map opens the annotation tab. Closing the annotation tab should reset the highlighted path on the map.

### 2. Word break fix for annotation prev and next tooltips.

![image](https://github.com/user-attachments/assets/eb230a90-936e-4205-ba59-7b6ccaeec9b4)

### 3. Fix word break for connectivity list error popup.
