### PR TITLE
Update citation format chicago

### DIFF
--- a/src/components/Tooltip/ExternalResourceCard.vue
+++ b/src/components/Tooltip/ExternalResourceCard.vue
@@ -98,7 +98,7 @@ const CITATION_OPTIONS = [
   },
   {
     label: 'Chicago',
-    value: 'chicago-note-bibliography',
+    value: 'chicago-author-date',
   },
   {
     label: 'IEEE',

--- a/src/components/Tooltip/ExternalResourceCard.vue
+++ b/src/components/Tooltip/ExternalResourceCard.vue
@@ -405,7 +405,7 @@ export default {
       return citation && !citation[this.citationType] && !citation.error;
     },
     isCitationError: function (citation) {
-      return citation && citation.error;
+      return citation && citation.error && citation.error.type === this.citationType;
     },
     updateCopyContents: function () {
       const citationTypeObj = this.citationOptions.find((item) => item.value === this.citationType);


### PR DESCRIPTION
The citation.doi.org website recently changed the Chicago style format for the `chicago-note-bibliography`. This change caused errors, even though it was working previously. Since [the portal has now fixed the issue](https://github.com/nih-sparc/sparc-app-2/pull/384/commits/1529ece863717e789e8b8d6c00f88c47bc91190c), we have also updated our component accordingly.

