### PR TITLE
Connectivity Graph Loading

### DIFF
--- a/src/components/ConnectivityGraph/ConnectivityGraph.vue
+++ b/src/components/ConnectivityGraph/ConnectivityGraph.vue
@@ -279,8 +279,10 @@ export default {
             this.showGraph(this.entry);
           } else if (res?.error) {
             this.loadingError = res.error;
+            this.hideSpinner();
           } else {
             this.loadingError = 'Loading error!';
+            this.hideSpinner();
           }
         })
         .catch((error) => {

--- a/src/components/ConnectivityGraph/ConnectivityGraph.vue
+++ b/src/components/ConnectivityGraph/ConnectivityGraph.vue
@@ -304,7 +304,7 @@ export default {
         this.availableSources = await this.loadAvailableSources();
       }
 
-      if (!this.isSCKANVersionAvailable()) {
+      if (!this.connectivityFromMap && !this.isSCKANVersionAvailable()) {
         return {
           error: `No data available for SCKAN version ${this.selectedSource}.`,
         };


### PR DESCRIPTION
When there are errors with SCKAN version for connectivity graph, 

- it should still load for MAP data
- it should hide the loading