### PR TITLE
Fix missing ilx:composer paths in fetching data for graph

### DIFF
--- a/src/components/ConnectivityGraph/ConnectivityGraph.vue
+++ b/src/components/ConnectivityGraph/ConnectivityGraph.vue
@@ -506,7 +506,7 @@ export default {
     loadPathData: async function (source) {
       const data = await this.query(
         `select entity, knowledge from knowledge
-          where entity like 'ilxtr:%' and source=?
+          where (entity like 'ilxtr:%' or entity like 'ilx:composer%') and source=?
           order by entity`,
         [source]);
       const pathList = data ? data.values : [];


### PR DESCRIPTION
### How to replicate the issue

- Select the "**Pathways: Enteric**"
- And click on the path id start with `ilx:composer`
- Click on the graph view
- The graph view cannot load

<img width="659" height="621" alt="image" src="https://github.com/user-attachments/assets/5971700c-9277-4dbc-96c8-c4896a8cee69" />


### Note

After applying the fix, the user needs to clear the cache and reload the page to get the paths data with `ilx:composer` in local storage. 


The fix can be tested on the demo app.
https://mapintegratedvuer-mapcore-754fcb3bf891.herokuapp.com/#/
