### PR TITLE
Update alert notes for provenance popup

### DIFF
--- a/src/components/Tooltip/ProvenancePopup.vue
+++ b/src/components/Tooltip/ProvenancePopup.vue
@@ -41,21 +41,15 @@
     <div class="block" v-else>
       <div class="title">{{ entry.featureId }}</div>
     </div>
-    <div v-if="entry.featuresAlert?.length" class="attribute-title-container">
-      <span class="attribute-title">Notes</span>
-      <el-popover
-        width="250"
-        trigger="hover"
-        :teleported="false"
-        popper-class="popover-origin-help"
-      >
-        <template #reference>
-          <el-icon class="info"><el-icon-warning /></el-icon>
-        </template>
-        <span style="word-break: keep-all">
-          {{ entry.featuresAlert.join(", ") }}
-        </span>
-      </el-popover>
+    <div v-if="entry.featuresAlert?.length" class="block">
+      <div class="attribute-title-container">
+        <div class="attribute-title">
+          Notes
+        </div>
+      </div>
+      <div style="word-break: keep-all">
+        {{ entry.featuresAlert.join(", ") }}
+      </div>
     </div>
     <div
       v-show="showDetails"

--- a/src/components/Tooltip/ProvenancePopup.vue
+++ b/src/components/Tooltip/ProvenancePopup.vue
@@ -29,20 +29,22 @@
     </div>
 
     <!-- Title -->
-    <div class="block" v-if="entry.title">
-      <div class="title">{{ capitalise(entry.title) }}</div>
-      <div
-        v-if="
-          entry.provenanceTaxonomyLabel &&
-          entry.provenanceTaxonomyLabel.length > 0
-        "
-        class="subtitle"
-      >
-        {{ provSpeciesDescription }}
+    <div>
+      <div class="block" v-if="entry.title">
+        <div class="title">{{ capitalise(entry.title) }}</div>
+        <div
+          v-if="
+            entry.provenanceTaxonomyLabel &&
+            entry.provenanceTaxonomyLabel.length > 0
+          "
+          class="subtitle"
+        >
+          {{ provSpeciesDescription }}
+        </div>
       </div>
-    </div>
-    <div class="block" v-else>
-      <div class="title">{{ entry.featureId }}</div>
+      <div class="block" v-else>
+        <div class="title">{{ entry.featureId }}</div>
+      </div>
     </div>
 
     <!-- Alert notes -->
@@ -59,7 +61,7 @@
         </el-icon>
       </div>
       <transition name="slide-fade">
-        <div v-show="showNotes" class="block">
+        <div v-show="showNotes" class="block collapse-block">
           <div class="alert-block"
             v-for="alert in entry.featuresAlert"
             v-html="formatAlertText(alert)"
@@ -69,45 +71,47 @@
     </div>
 
     <!-- Connectiity info -->
-    <div
-      v-show="showDetails"
-      class="collapse-toggle"
-      id="hide-path-info"
-      @click="showDetails = false"
-    >
-      Hide path information
-      <el-icon><el-icon-arrow-up /></el-icon>
-    </div>
-    <div
-      v-show="!showDetails"
-      class="collapse-toggle"
-      id="show-path-info"
-      @click="showDetails = true"
-    >
-      Show path information
-      <el-icon><el-icon-arrow-down /></el-icon>
-    </div>
-    <transition name="slide-fade">
-      <div v-show="showDetails" class="content-container scrollbar">
-        <connectivity-list
-          :key="entry.featureId[0]"
-          :entry="entry"
-          :origins="origins"
-          :components="components"
-          :destinations="destinations"
-          :originsWithDatasets="originsWithDatasets"
-          :componentsWithDatasets="componentsWithDatasets"
-          :destinationsWithDatasets="destinationsWithDatasets"
-          :availableAnatomyFacets="availableAnatomyFacets"
-          :connectivityError="connectivityError"
-          @connectivity-action-click="onConnectivityActionClick"
-        />
-        <external-resource-card
-          v-if="resources.length"
-          :resources="resources"
-        />
+    <div>
+      <div
+        v-show="showDetails"
+        class="collapse-toggle"
+        id="hide-path-info"
+        @click="showDetails = false"
+      >
+        Hide path information
+        <el-icon><el-icon-arrow-up /></el-icon>
       </div>
-    </transition>
+      <div
+        v-show="!showDetails"
+        class="collapse-toggle"
+        id="show-path-info"
+        @click="showDetails = true"
+      >
+        Show path information
+        <el-icon><el-icon-arrow-down /></el-icon>
+      </div>
+      <transition name="slide-fade">
+        <div v-show="showDetails" class="content-container scrollbar collapse-block">
+          <connectivity-list
+            :key="entry.featureId[0]"
+            :entry="entry"
+            :origins="origins"
+            :components="components"
+            :destinations="destinations"
+            :originsWithDatasets="originsWithDatasets"
+            :componentsWithDatasets="componentsWithDatasets"
+            :destinationsWithDatasets="destinationsWithDatasets"
+            :availableAnatomyFacets="availableAnatomyFacets"
+            :connectivityError="connectivityError"
+            @connectivity-action-click="onConnectivityActionClick"
+          />
+          <external-resource-card
+            v-if="resources.length"
+            :resources="resources"
+          />
+        </div>
+      </transition>
+    </div>
   </div>
 </template>
 
@@ -283,7 +287,6 @@ export default {
 .toggle-button {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
   padding-right: 0.75rem; // for close button
 
   .is-disabled {
@@ -300,13 +303,15 @@ export default {
   font-size: 18px;
   font-family: Helvetica;
   font-weight: bold;
-  padding-bottom: 8px;
+  padding-right: 0.75rem; // for close button
   color: $app-primary-color;
 }
 
-.block {
-  margin-bottom: 0.5em;
+.subtitle {
+  margin-top: 8px;
+}
 
+.block {
   .main > &:first-of-type {
     margin-right: 1em;
   }
@@ -321,8 +326,11 @@ export default {
 .collapse-toggle {
   color: $app-primary-color;
   cursor: pointer;
-  margin-right: 6px;
-  margin-top: 3px;
+  margin-right: 0.75rem;
+}
+
+.collapse-block {
+  margin-top: 0.5rem;
 }
 
 .main {
@@ -335,6 +343,9 @@ export default {
   padding: 1em !important;
   overflow: hidden;
   min-width: 16rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .attribute-title-container {
@@ -451,10 +462,6 @@ export default {
 
   .block {
     padding-top: 0.5em;
-  }
-
-  .connectivity-list {
-    padding-top: 1rem;
   }
 }
 

--- a/src/components/Tooltip/ProvenancePopup.vue
+++ b/src/components/Tooltip/ProvenancePopup.vue
@@ -47,9 +47,10 @@
           Notes
         </div>
       </div>
-      <div style="word-break: keep-all">
-        {{ entry.featuresAlert.join(", ") }}
-      </div>
+      <div class="alert-block"
+        v-for="alert in entry.featuresAlert"
+        v-html="formatAlertText(alert)"
+      ></div>
     </div>
     <div
       v-show="showDetails"
@@ -223,6 +224,38 @@ export default {
         this.availableAnatomyFacets = JSON.parse(availableAnatomyFacets);
       }
     },
+    formatAlertText: function (text) {
+      if (!text) return '';
+      const escaped = text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      const linkified = escaped.replace(
+        /(https?:\/\/[^\s"<>\[]+)/g,
+        (url) => {
+          const parts = url.match(/^(.*?)([\].,;:!?]*)$/);
+          const cleanUrl = parts ? parts[1] : url;
+          const suffix = parts ? parts[2] : '';
+          return `<a href="${cleanUrl}" target="_blank" rel="noopener noreferrer">${cleanUrl}</a>${suffix}`;
+        }
+      );
+
+      const normalised = linkified
+        .replace(/\\n/g, '\n')
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n');
+
+      return normalised
+        .split('\n')
+        .map((line) => {
+          const withBoldLabel = line.replace(
+            /^\s*([A-Za-z][^:<]{0,120}:)/,
+            '<strong>$1</strong>'
+          );
+          return `<div class="alert-line">${withBoldLabel}</div>`;
+        })
+        .join('\n');
+    },
   },
 };
 </script>
@@ -366,6 +399,26 @@ export default {
     &::before {
       margin: 0 auto;
       border-color: transparent transparent $app-primary-color transparent;
+    }
+  }
+}
+
+.alert-block {
+  background-color: var(--el-color-warning-light-9);
+  border: 1px dashed var(--el-color-warning);
+  padding: 0.75rem;
+  border-radius: 4px;
+
+  :deep(.alert-line + .alert-line) {
+    margin-top: 0.5rem;
+  }
+
+  :deep(a) {
+    color: $app-primary-color;
+    word-break: break-all;
+
+    &:hover {
+      opacity: 0.8;
     }
   }
 }

--- a/src/components/Tooltip/ProvenancePopup.vue
+++ b/src/components/Tooltip/ProvenancePopup.vue
@@ -48,7 +48,7 @@
     <!-- Alert notes -->
     <div v-if="entry.featuresAlert?.length">
       <div
-        class="hide"
+        class="collapse-toggle"
         id="toggle-notes"
         @click="showNotes = !showNotes"
       >
@@ -71,7 +71,7 @@
     <!-- Connectiity info -->
     <div
       v-show="showDetails"
-      class="hide"
+      class="collapse-toggle"
       id="hide-path-info"
       @click="showDetails = false"
     >
@@ -80,7 +80,7 @@
     </div>
     <div
       v-show="!showDetails"
-      class="hide"
+      class="collapse-toggle"
       id="show-path-info"
       @click="showDetails = true"
     >
@@ -316,7 +316,7 @@ export default {
   margin-left: 8px;
 }
 
-.hide {
+.collapse-toggle {
   color: $app-primary-color;
   cursor: pointer;
   margin-right: 6px;

--- a/src/components/Tooltip/ProvenancePopup.vue
+++ b/src/components/Tooltip/ProvenancePopup.vue
@@ -41,16 +41,31 @@
     <div class="block" v-else>
       <div class="title">{{ entry.featureId }}</div>
     </div>
-    <div v-if="entry.featuresAlert?.length" class="block">
-      <div class="attribute-title-container">
-        <div class="attribute-title">
-          Notes
-        </div>
+    <div v-if="entry.featuresAlert?.length">
+      <div
+        class="hide"
+        id="toggle-notes"
+        @click="showNotes = !showNotes"
+      >
+        Notes
+        <el-icon>
+          <el-icon-arrow-up v-if="showNotes" />
+          <el-icon-arrow-down v-else />
+        </el-icon>
       </div>
-      <div class="alert-block"
-        v-for="alert in entry.featuresAlert"
-        v-html="formatAlertText(alert)"
-      ></div>
+      <transition name="slide-fade">
+        <div v-show="showNotes" class="block">
+          <div class="attribute-title-container">
+            <div class="attribute-title">
+              Notes
+            </div>
+          </div>
+          <div class="alert-block"
+            v-for="alert in entry.featuresAlert"
+            v-html="formatAlertText(alert)"
+          ></div>
+        </div>
+      </transition>
     </div>
     <div
       v-show="showDetails"
@@ -124,6 +139,7 @@ export default {
     return {
       loading: false,
       showDetails: false,
+      showNotes: false,
       originDescriptions: {
         motor: "is the location of the initial cell body of the circuit",
         sensory: "is the location of the initial cell body in the PNS circuit",
@@ -187,6 +203,7 @@ export default {
       handler: function (newVal, oldVal) {
         if (newVal !== oldVal) {
           this.entryIndex = 0;
+          this.showNotes = false;
         }
       },
     },

--- a/src/components/Tooltip/ProvenancePopup.vue
+++ b/src/components/Tooltip/ProvenancePopup.vue
@@ -41,8 +41,8 @@
     <div class="block" v-else>
       <div class="title">{{ entry.featureId }}</div>
     </div>
-    <div v-if="entry.featuresAlert" class="attribute-title-container">
-      <span class="attribute-title">Alert</span>
+    <div v-if="entry.featuresAlert?.length" class="attribute-title-container">
+      <span class="attribute-title">Notes</span>
       <el-popover
         width="250"
         trigger="hover"
@@ -53,7 +53,7 @@
           <el-icon class="info"><el-icon-warning /></el-icon>
         </template>
         <span style="word-break: keep-all">
-          {{ entry.featuresAlert }}
+          {{ entry.featuresAlert.join(", ") }}
         </span>
       </el-popover>
     </div>

--- a/src/components/Tooltip/ProvenancePopup.vue
+++ b/src/components/Tooltip/ProvenancePopup.vue
@@ -283,6 +283,8 @@ export default {
 .toggle-button {
   display: flex;
   justify-content: space-between;
+  margin-bottom: 0.5rem;
+  padding-right: 0.75rem; // for close button
 
   .is-disabled {
     color: #fff !important;

--- a/src/components/Tooltip/ProvenancePopup.vue
+++ b/src/components/Tooltip/ProvenancePopup.vue
@@ -55,11 +55,6 @@
       </div>
       <transition name="slide-fade">
         <div v-show="showNotes" class="block">
-          <div class="attribute-title-container">
-            <div class="attribute-title">
-              Notes
-            </div>
-          </div>
           <div class="alert-block"
             v-for="alert in entry.featuresAlert"
             v-html="formatAlertText(alert)"

--- a/src/components/Tooltip/ProvenancePopup.vue
+++ b/src/components/Tooltip/ProvenancePopup.vue
@@ -1,5 +1,6 @@
 <template>
   <div v-if="entry" class="main" v-loading="loading">
+    <!-- Navigation -->
     <div v-if="tooltipEntry.length > 1" class="toggle-button">
       <el-popover width="auto" trigger="hover" :teleported="false">
         <template #reference>
@@ -26,6 +27,8 @@
         <span>{{ nextLabel }}</span>
       </el-popover>
     </div>
+
+    <!-- Title -->
     <div class="block" v-if="entry.title">
       <div class="title">{{ capitalise(entry.title) }}</div>
       <div
@@ -41,6 +44,8 @@
     <div class="block" v-else>
       <div class="title">{{ entry.featureId }}</div>
     </div>
+
+    <!-- Alert notes -->
     <div v-if="entry.featuresAlert?.length">
       <div
         class="hide"
@@ -62,6 +67,8 @@
         </div>
       </transition>
     </div>
+
+    <!-- Connectiity info -->
     <div
       v-show="showDetails"
       class="hide"


### PR DESCRIPTION
This update changes "alert" to "notes" and formats alert notes for the provenance popup in `flatmapvuer`.

### Updated styles and format

The alert note is now showing as a collapse toggle, similar to connectivity information.

<img width="313" height="178" alt="image" src="https://github.com/user-attachments/assets/cc99a90c-fceb-4ccc-a946-65ed00c0728e" />

<img width="349" height="524" alt="image" src="https://github.com/user-attachments/assets/6186310f-a9d5-43d0-9393-1389d682b21b" />

### Related PR
- https://github.com/ABI-Software/flatmapvuer/pull/337
